### PR TITLE
Set default font of manifest.json for the 'demo-theme'

### DIFF
--- a/themes/demo-theme/manifest.json
+++ b/themes/demo-theme/manifest.json
@@ -3,6 +3,10 @@
   "label": "Demo Theme",
   "type": "theme",
   "thumbnails ": [],
+  "font": {
+    "fontFamily": "Avenir Next",
+    "color": "#484848"
+  },
   "version": "1.13.0",
   "exbVersion": "1.13.0",
   "author": "Esri R&D Center Beijing",


### PR DESCRIPTION
Set default font parameters for the 'demo-theme' to prevent theme names from being invisible on the theme selection (because both background and text colors are white).

Before
<img width="304" alt="image" src="https://github.com/blissvisitor/arcgis-experience-builder-sdk-resources/assets/16833909/f0105a60-9fef-4b94-93b6-e27e7b2ee061">

After
<img width="296" alt="image" src="https://github.com/blissvisitor/arcgis-experience-builder-sdk-resources/assets/16833909/efa24cb9-356e-474e-b867-e5ceae12e218">

