### PR TITLE
fix:Set default font parameters for the demo-theme 

### DIFF
--- a/themes/demo-theme/manifest.json
+++ b/themes/demo-theme/manifest.json
@@ -3,6 +3,10 @@
   "label": "Demo Theme",
   "type": "theme",
   "thumbnails ": [],
+  "font": {
+    "fontFamily": "Avenir Next",
+    "color": "#484848"
+  },
   "version": "1.13.0",
   "exbVersion": "1.13.0",
   "author": "Esri R&D Center Beijing",


### PR DESCRIPTION
Set default font parameters for the demo-theme  from being invisible on the theme selection (because both background and text colors are white).

 **Before**
<img width="240" alt="image" src="https://github.com/blissvisitor/arcgis-experience-builder-sdk-resources/assets/16833909/8568f551-c2d3-40b4-a5bc-f4265adee940">

**After**

<img width="253" alt="image" src="https://github.com/blissvisitor/arcgis-experience-builder-sdk-resources/assets/16833909/947303c4-e806-4ac0-b0ef-0d99bbec3a42">
